### PR TITLE
replaceView didn't properly clean up old view

### DIFF
--- a/backbone.viewkit.js
+++ b/backbone.viewkit.js
@@ -127,6 +127,7 @@
 
             if (popped) {
                 this._cleanup(popped);
+                popped.remove();
             }
 
             view.viewStack = this;


### PR DESCRIPTION
Semantically replaceView should be popView + pushView, but it missed calling `popped.remove()`. Fixed to call it for the replaced view.
